### PR TITLE
Add a manage.py file for easier development.

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import sys
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)


### PR DESCRIPTION
Thanks again for building this repo!

Usually when forking a django app repo I see a `manage.py` file - this PR simply adds one that I adapted from [django-extensions](https://github.com/django-extensions/django-extensions/blob/master/manage.py).

I'm not aware of a reason not to have this but if there is one feel free to close it!